### PR TITLE
Поправил две ошибки

### DIFF
--- a/users.go
+++ b/users.go
@@ -147,11 +147,11 @@ func (u *Users) List(ctx context.Context, options *ListUsersOptions) (users []Us
 
 		users = append(users, usersResponse...)
 
-		if len(usersResponse) < options.Per {
+		if len(usersResponse) == options.Per {
+			options.Page++
+		} else {
 			break
 		}
-
-		options.Page++
 	}
 
 	return users, resp, nil

--- a/users.go
+++ b/users.go
@@ -93,9 +93,9 @@ func (u *Users) getUsersPaginated(ctx context.Context, options *ListUsersOptions
 	resp, err := u.client.R().
 		SetContext(ctx).
 		SetQueryParams(map[string]string{
-			"Per":   fmt.Sprint(options.Per),
-			"Page":  fmt.Sprint(options.Page),
-			"Query": options.Query,
+			"per":   fmt.Sprint(options.Per),
+			"page":  fmt.Sprint(options.Page),
+			"query": options.Query,
 		}).
 		Get(usersURL)
 	if err != nil {


### PR DESCRIPTION
Первая ошибка в синтаксисе: API пачки требует чтобы параметры были строго lower case, иначе `query` не работает.

Вторая ошибка в логике, из-за нее получался бесконечный цикл.

Моя логика такая: если количество `userResponse` равно количество записей выдаваемых на страницу, то можно попробовать достать следующую страницу. В остальных случаях выходим и возвращаем ответ.